### PR TITLE
Change version format and refactor with staticcheck

### DIFF
--- a/blockchain-watchdog/alerts.go
+++ b/blockchain-watchdog/alerts.go
@@ -25,7 +25,7 @@ Time since last new block: %d seconds (%f minutes)
 See: http://watchdog.hmny.io/report-%s
 `
 	crossShardTransactionMessage = `
-Cx Transaction Pool too large on shard %s!
+Cx Transaction Pool too large on shard %d!
 
 Count: %d
 `
@@ -34,14 +34,14 @@ Haven't processed a cross link for shard %d in a while!
 
 Cross Link Hash: %s
 
-Shard %d Block: %s
+Shard %d Block: %d
 
-Shard %d Epoch: %s
+Shard %d Epoch: %d
 
 Signature: %s
 
 Signature Bitmap: %s
 
-Time since last processed cross link: %d seconds (%f minutes)
+Time since last processed cross link: %f seconds (%f minutes)
 `
 )

--- a/blockchain-watchdog/crosslink-monitor.go
+++ b/blockchain-watchdog/crosslink-monitor.go
@@ -37,10 +37,6 @@ func (m *monitor) crossLinkMonitor(interval, warning uint64, poolSize int, pdSer
 		Result NodeMetadataReply `json:"result"`
 	}
 
-	type t struct {
-		Result []CrossLink `json:"result"`
-	}
-
 	type processedCrossLink struct {
 		BlockNum  int
 		CrossLink CrossLink
@@ -94,7 +90,7 @@ func (m *monitor) crossLinkMonitor(interval, warning uint64, poolSize int, pdSer
 					if entry, exists := lastProcessed[result.ShardID]; exists {
 						elapsedTime := now.Sub(entry.TS)
 						if result.BlockNumber <= entry.BlockNum {
-						  if uint64(elapsedTime.Seconds()) >= warning {
+							if uint64(elapsedTime.Seconds()) >= warning {
 								message := fmt.Sprintf(crossLinkMessage, result.ShardID,
 									result.Hash, result.ShardID, result.BlockNumber, result.ShardID,
 									result.EpochNumber, result.Signature, result.SignatureBitmap,

--- a/blockchain-watchdog/html-generators.go
+++ b/blockchain-watchdog/html-generators.go
@@ -173,7 +173,7 @@ hr:after {
         {{ with (index .Summary "node-metadata") }}
         {{range $key, $value := .}}
           <div class="flex-col center stat-box">
-            <a href="#version-{{$key}}">Version-{{$key}}</a>
+            <a href="#version-{{$key}}">{{$key}}</a>
             <p>
               Node Count:{{ len (index $value "records") }}
               {{ with getCommitID $key }}

--- a/blockchain-watchdog/reporting-server.go
+++ b/blockchain-watchdog/reporting-server.go
@@ -124,7 +124,7 @@ func summaryMaps(metas []NodeMetadata, headers []BlockHeader) summary {
 	}
 
 	linq.From(metas).GroupBy(
-		func(node interface{}) interface{} { return parseVersionS(node.(NodeMetadata).Payload.Version) }, identity,
+		func(node interface{}) interface{} { return node.(NodeMetadata).Payload.Version }, identity,
 	).ForEach(func(value interface{}) {
 		vrs := value.(linq.Group).Key.(string)
 		sum[metaSumry][vrs] = map[string]interface{}{"records": value.(linq.Group).Group}
@@ -194,7 +194,7 @@ func (m *monitor) renderReport(w http.ResponseWriter, req *http.Request) {
 		Funcs(template.FuncMap{
 			"getCommitID": func(version string) string {
 				r := strings.Split(version, `-g`)
-				r = strings.Split(r[len(r)-1], "-")
+				r = strings.Split(r[len(r)-1], " ")
 				return r[0]
 			},
 			"currentCommitteeCount": func(shardID string) string {

--- a/blockchain-watchdog/reporting-server.go
+++ b/blockchain-watchdog/reporting-server.go
@@ -564,11 +564,7 @@ func (m *monitor) cxMonitor(interval uint64, poolSize int, pdServiceKey, chain s
 				json.Unmarshal(d.rpcResult, &oneReport)
 				if oneReport.Result.IsLeader {
 					shard := int(oneReport.Result.ShardID)
-					if _, exists := leaders[shard]; exists {
-						leaders[shard] = append(leaders[shard], d.address)
-					} else {
-						leaders[shard] = []string{d.address}
-					}
+					leaders[shard] = append(leaders[shard], d.address)
 				}
 			}
 		}
@@ -602,14 +598,10 @@ func (m *monitor) cxMonitor(interval uint64, poolSize int, pdServiceKey, chain s
 						}
 					}
 				}
-				if _, exists := cxPoolSize[shard]; exists {
-					cxPoolSize[shard] = append(cxPoolSize[shard], report.Result)
-				} else {
-					cxPoolSize[shard] = []uint64{report.Result}
-				}
+				cxPoolSize[shard] = append(cxPoolSize[shard], report.Result)
 				if report.Result > uint64(1000) {
 					message := fmt.Sprintf(crossShardTransactionMessage, shard, report.Result)
-					incidentKey := fmt.Sprintf("Shard %s cx transaction pool size > 1000! - %s", shard, chain)
+					incidentKey := fmt.Sprintf("Shard %d cx transaction pool size > 1000! - %s", shard, chain)
 					err := notify(pdServiceKey, incidentKey, chain, message)
 					if err != nil {
 						errlog.Print(err)

--- a/blockchain-watchdog/reporting-server.go
+++ b/blockchain-watchdog/reporting-server.go
@@ -198,10 +198,10 @@ func (m *monitor) renderReport(w http.ResponseWriter, req *http.Request) {
 				return r[0]
 			},
 			"currentCommitteeCount": func(shardID string) string {
-				return strconv.Itoa(m.SuperCommittee.CurrentCommittee.Deciders[shardID].Externals)
+				return strconv.Itoa(m.SuperCommittee.CurrentCommittee.Deciders["shard-"+shardID].Externals)
 			},
 			"previousCommitteeCount": func(shardID string) string {
-				return strconv.Itoa(m.SuperCommittee.PreviousCommittee.Deciders[shardID].Externals)
+				return strconv.Itoa(m.SuperCommittee.PreviousCommittee.Deciders["shard-"+shardID].Externals)
 			},
 			"getShardID": func(s string) string {
 				return s[len(s)-1:]

--- a/blockchain-watchdog/rpc.go
+++ b/blockchain-watchdog/rpc.go
@@ -18,8 +18,8 @@ type NodeMetadataReply struct {
 	ShardID        uint32   `json:"shard-id"`
 	NodeRole       string   `json:"role"`
 	BlocksPerEpoch int      `json:"blocks-per-epoch"`
-	DNSZone        string   `json:"dns-zone,omit-empty"`
-	ArchivalNode   bool     `json:"is-archival,omit-empty"`
+	DNSZone        string   `json:"dns-zone,omitempty"`
+	ArchivalNode   bool     `json:"is-archival,omitempty"`
 	ChainConfig    struct {
 		ChainID         int `json:"chain-id"`
 		CrossLinkEpoch  int `json:"cross-link-epoch"`
@@ -52,20 +52,6 @@ type BlockHeaderReply struct {
 type BlockHeader struct {
 	Payload BlockHeaderReply
 	IP      string
-}
-
-// TODO: Come back to this
-type PendingCXReply struct {
-	PendingCX []CXReceiptProof `json:"-"`
-}
-
-// Don't care about contents of each Receipt
-type CXReceiptProof struct {
-	Receipts     interface{} `json:"receipts"`
-	MerkleProof  interface{} `json:"merkleProof"`
-	Header       interface{} `json:"header"`
-	CommitSig    string      `json:"commitSig"`
-	CommitBitmap string      `json:"commitBitmap"`
 }
 
 type SuperCommitteeReply struct {


### PR DESCRIPTION
## Changes
* Removed parseVersionS() function
  * Refactored getCommitID template function
* Refactored code mentioned by running staticcheck (and derivatives): 
```
crosslink-monitor.go:40:7: type t is unused (U1000)
crosslink-monitor.go:98:32: Printf format %s has arg #4 of wrong type int (SA5009)
reporting-server.go:567:6: unnecessary guard around map access (S1036)
reporting-server.go:605:5: unnecessary guard around map access (S1036)
reporting-server.go:611:29: Printf format %s has arg #1 of wrong type int (SA5009)
reporting-server.go:612:33: Printf format %s has arg #1 of wrong type int (SA5009)
root.go:31:2: var sep is unused (U1000)
root.go:32:2: var recordSep is unused (U1000)
root.go:147:41: os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)
root.go:162:2: should use for range instead of for { select {} } (S1000)
root.go:285:15: error strings should not be capitalized (ST1005)
root.go:285:15: error strings should not end with punctuation or a newline (ST1005)
root.go:347:8: const versionSep is unused (U1000)
rpc.go:21:26: unknown JSON option "omit-empty" (SA5008)
rpc.go:22:26: unknown JSON option "omit-empty" (SA5008)
rpc.go:58:6: type PendingCXReply is unused (U1000)
rpc.go:63:6: type CXReceiptProof is unused (U1000)
```
