### PR TITLE
Revert "[#14] Add delay to allow time for node to sync before fetching new committee data"

### DIFF
--- a/blockchain-watchdog/reporting-server.go
+++ b/blockchain-watchdog/reporting-server.go
@@ -454,7 +454,6 @@ func (m *monitor) worker(
 }
 
 func (m *monitor) stakingCommitteeUpdate(beaconChainNode string) {
-	time.Sleep(time.Second * time.Duration(5)) // Add delay to allow node to sync before update
 	stdlog.Print("[stakingCommitteeUpdate] Updating super committees")
 	committeeRequestFields := getRPCRequest(SuperCommitteeRPC)
 


### PR DESCRIPTION
Reverts harmony-one/watchdog#15